### PR TITLE
Add description to config file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,7 @@ category: "reference and outreach"
 tags:
   - "workflow"
 title: "Usability Testing Templates"
+description: Templates and guides for usability testing at the Rockefeller Archive Center.
 pages:
   - ["Usability Testing at the Rockefeller Archive Center", "index"]
   - ["Facilitator Script", "facilitator-script"]


### PR DESCRIPTION
[docs.rockarch.org](docs.rockarch.org) is now using the description text from the `_config.yml` file as the meta description in the document head of each page, so I've added a description for this set of docs.